### PR TITLE
Rebuild HUB landing on plain Astro (remove Starlight dependency)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,89 +1,10 @@
 // @ts-check
-import { SITE_TITLE } from './src/consts';
 import { defineConfig } from 'astro/config';
-import remarkMath from 'remark-math';
-import rehypeKatex from 'rehype-katex';
-import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
-import starlight from '@astrojs/starlight';
-import partytown from '@astrojs/partytown';
-import rehypeMermaid from 'rehype-mermaid';
 
-// https://astro.build/config
 export default defineConfig({
   site: 'https://weekend-thinker.com/',
-  integrations: [
-    starlight({
-      title: SITE_TITLE,
-      favicon: 'favicon.ico',
-      logo: { src: './src/assets/logo.svg', alt: SITE_TITLE + 'の画像' },
-      social: [
-        { icon: 'github', label: 'github', href: 'https://github.com/LogPiyo'},
-        { icon: 'x.com', label: 'x', href: 'https://x.com/LogPiyoo'},
-      ],
-      sidebar: [
-        {
-          label: 'コンピュータサイエンス',
-          autogenerate: {directory: '/blog/computer'},
-        },
-        {
-          label: '物理学・数学',
-          autogenerate: {directory: '/blog/physics'},
-        },
-        {
-          label: '論理学',
-          autogenerate: {directory: '/blog/logic'},
-        },
-        {
-          label: '雑記',
-          autogenerate: {directory: '/blog/misc'},
-          collapsed: true,
-        },
-      ],
-      head: [
-        {
-          tag: 'link',
-          attrs: {
-            rel: 'stylesheet',
-            href: 'https://cdn.jsdelivr.net/npm/katex@0.16.22/dist/katex.min.css',
-            integrity: 'sha384-5TcZemv2l/9On385z///+d7MSYlvIEw9FuZTIdZ14vJLqWphw7e7ZPuOiCHJcFCP',
-            crossorigin: 'anonymous',
-          }
-        }
-      ],
-      customCss: [
-        './src/styles/custom.css',
-      ],
-      components: {
-        Head: './src/components/Head.astro',
-        Footer: './src/components/Footer.astro',
-      },
-      locales: {
-        root: {
-          label: '日本語',
-          lang: 'ja',
-        }
-      }
-    }),
-    sitemap(), 
-    mdx(), 
-    partytown({
-      config: {
-        forward: ["dataLayer.push"],
-      }
-    }),
-  ],
-  markdown: {
-    syntaxHighlight: {
-      excludeLangs: ['mermaid'],
-    },
-    remarkPlugins: [remarkMath],
-    rehypePlugins: [
-      [
-        rehypeKatex,
-        {output: 'mathml'}
-      ],
-      rehypeMermaid,
-    ]
-  },
+  integrations: [sitemap()],
+  output: 'static',
+  compressHTML: true,
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@astrojs/mdx": "^4.3.4",
         "@astrojs/rss": "^4.0.12",
         "@astrojs/sitemap": "^3.5.0",
-        "@astrojs/starlight": "^0.35.2",
         "@playwright/test": "^1.54.2",
         "astro": "^5.13.2",
         "rehype-katex": "^7.0.1",
@@ -165,44 +164,6 @@
         "zod": "^3.24.4"
       }
     },
-    "node_modules/@astrojs/starlight": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.35.2.tgz",
-      "integrity": "sha512-curGghoW4s5pCbW2tINsJPoxEYPan87ptCOv7GZ+S24N3J6AyaOu/OsjZDEMaIpo3ZlObM5DQn+w7iXl3drDhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@astrojs/markdown-remark": "^6.3.1",
-        "@astrojs/mdx": "^4.2.3",
-        "@astrojs/sitemap": "^3.3.0",
-        "@pagefind/default-ui": "^1.3.0",
-        "@types/hast": "^3.0.4",
-        "@types/js-yaml": "^4.0.9",
-        "@types/mdast": "^4.0.4",
-        "astro-expressive-code": "^0.41.1",
-        "bcp-47": "^2.1.0",
-        "hast-util-from-html": "^2.0.1",
-        "hast-util-select": "^6.0.2",
-        "hast-util-to-string": "^3.0.0",
-        "hastscript": "^9.0.0",
-        "i18next": "^23.11.5",
-        "js-yaml": "^4.1.0",
-        "klona": "^2.0.6",
-        "mdast-util-directive": "^3.0.0",
-        "mdast-util-to-markdown": "^2.1.0",
-        "mdast-util-to-string": "^4.0.0",
-        "pagefind": "^1.3.0",
-        "rehype": "^13.0.1",
-        "rehype-format": "^5.0.0",
-        "remark-directive": "^3.0.0",
-        "ultrahtml": "^1.6.0",
-        "unified": "^11.0.5",
-        "unist-util-visit": "^5.0.0",
-        "vfile": "^6.0.2"
-      },
-      "peerDependencies": {
-        "astro": "^5.5.0"
-      }
-    },
     "node_modules/@astrojs/telemetry": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
@@ -252,15 +213,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
-      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -457,15 +409,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@ctrl/tinycolor": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-4.1.0.tgz",
-      "integrity": "sha512-WyOx8cJQ+FQus4Mm4uPIZA64gbk3Wxh0so5Lcii0aJifqwoVOlfFtorjLE0Hen4OYyHZMXDWqMmaQemBhgxFRQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -893,51 +836,6 @@
       ],
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@expressive-code/core": {
-      "version": "0.41.3",
-      "resolved": "https://registry.npmjs.org/@expressive-code/core/-/core-0.41.3.tgz",
-      "integrity": "sha512-9qzohqU7O0+JwMEEgQhnBPOw5DtsQRBXhW++5fvEywsuX44vCGGof1SL5OvPElvNgaWZ4pFZAFSlkNOkGyLwSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@ctrl/tinycolor": "^4.0.4",
-        "hast-util-select": "^6.0.2",
-        "hast-util-to-html": "^9.0.1",
-        "hast-util-to-text": "^4.0.1",
-        "hastscript": "^9.0.0",
-        "postcss": "^8.4.38",
-        "postcss-nested": "^6.0.1",
-        "unist-util-visit": "^5.0.0",
-        "unist-util-visit-parents": "^6.0.1"
-      }
-    },
-    "node_modules/@expressive-code/plugin-frames": {
-      "version": "0.41.3",
-      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-frames/-/plugin-frames-0.41.3.tgz",
-      "integrity": "sha512-rFQtmf/3N2CK3Cq/uERweMTYZnBu+CwxBdHuOftEmfA9iBE7gTVvwpbh82P9ZxkPLvc40UMhYt7uNuAZexycRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@expressive-code/core": "^0.41.3"
-      }
-    },
-    "node_modules/@expressive-code/plugin-shiki": {
-      "version": "0.41.3",
-      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-shiki/-/plugin-shiki-0.41.3.tgz",
-      "integrity": "sha512-RlTARoopzhFJIOVHLGvuXJ8DCEme/hjV+ZnRJBIxzxsKVpGPW4Oshqg9xGhWTYdHstTsxO663s0cdBLzZj9TQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@expressive-code/core": "^0.41.3",
-        "shiki": "^3.2.2"
-      }
-    },
-    "node_modules/@expressive-code/plugin-text-markers": {
-      "version": "0.41.3",
-      "resolved": "https://registry.npmjs.org/@expressive-code/plugin-text-markers/-/plugin-text-markers-0.41.3.tgz",
-      "integrity": "sha512-SN8tkIzDpA0HLAscEYD2IVrfLiid6qEdE9QLlGVSxO1KEw7qYvjpbNBQjUjMr5/jvTJ7ys6zysU2vLPHE0sb2g==",
-      "license": "MIT",
-      "dependencies": {
-        "@expressive-code/core": "^0.41.3"
       }
     },
     "node_modules/@fortawesome/fontawesome-free": {
@@ -1428,77 +1326,6 @@
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
-    },
-    "node_modules/@pagefind/darwin-arm64": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.3.0.tgz",
-      "integrity": "sha512-365BEGl6ChOsauRjyVpBjXybflXAOvoMROw3TucAROHIcdBvXk9/2AmEvGFU0r75+vdQI4LJdJdpH4Y6Yqaj4A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@pagefind/darwin-x64": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.3.0.tgz",
-      "integrity": "sha512-zlGHA23uuXmS8z3XxEGmbHpWDxXfPZ47QS06tGUq0HDcZjXjXHeLG+cboOy828QIV5FXsm9MjfkP5e4ZNbOkow==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@pagefind/default-ui": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@pagefind/default-ui/-/default-ui-1.3.0.tgz",
-      "integrity": "sha512-CGKT9ccd3+oRK6STXGgfH+m0DbOKayX6QGlq38TfE1ZfUcPc5+ulTuzDbZUnMo+bubsEOIypm4Pl2iEyzZ1cNg==",
-      "license": "MIT"
-    },
-    "node_modules/@pagefind/linux-arm64": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.3.0.tgz",
-      "integrity": "sha512-8lsxNAiBRUk72JvetSBXs4WRpYrQrVJXjlRRnOL6UCdBN9Nlsz0t7hWstRk36+JqHpGWOKYiuHLzGYqYAqoOnQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@pagefind/linux-x64": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.3.0.tgz",
-      "integrity": "sha512-hAvqdPJv7A20Ucb6FQGE6jhjqy+vZ6pf+s2tFMNtMBG+fzcdc91uTw7aP/1Vo5plD0dAOHwdxfkyw0ugal4kcQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@pagefind/windows-x64": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.3.0.tgz",
-      "integrity": "sha512-BR1bIRWOMqkf8IoU576YDhij1Wd/Zf2kX/kCI0b2qzCKC8wcc2GQJaaRMCpzvCCrmliO4vtJ6RITp/AnoYUUmQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/@playwright/test": {
       "version": "1.54.2",
@@ -2245,12 +2072,6 @@
         "@types/unist": "*"
       }
     },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
-      "license": "MIT"
-    },
     "node_modules/@types/katex": {
       "version": "0.16.7",
       "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.7.tgz",
@@ -2579,18 +2400,6 @@
         "sharp": "^0.33.3"
       }
     },
-    "node_modules/astro-expressive-code": {
-      "version": "0.41.3",
-      "resolved": "https://registry.npmjs.org/astro-expressive-code/-/astro-expressive-code-0.41.3.tgz",
-      "integrity": "sha512-u+zHMqo/QNLE2eqYRCrK3+XMlKakv33Bzuz+56V1gs8H0y6TZ0hIi3VNbIxeTn51NLn+mJfUV/A0kMNfE4rANw==",
-      "license": "MIT",
-      "dependencies": {
-        "rehype-expressive-code": "^0.41.3"
-      },
-      "peerDependencies": {
-        "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0"
-      }
-    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -2636,31 +2445,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/bcp-47": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bcp-47/-/bcp-47-2.1.0.tgz",
-      "integrity": "sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w==",
-      "license": "MIT",
-      "dependencies": {
-        "is-alphabetical": "^2.0.0",
-        "is-alphanumerical": "^2.0.0",
-        "is-decimal": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/bcp-47-match": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
-      "integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
@@ -2692,6 +2476,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/boxen": {
@@ -3029,22 +2814,6 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
-    },
-    "node_modules/css-selector-parser": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-3.1.3.tgz",
-      "integrity": "sha512-gJMigczVZqYAk0hPVzx/M4Hm1D9QOtqkdQk9005TNzDIUGzo5cnHEDiKUT7jGPximL/oYb+LIitcHFQ4aKupxg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/mdevils"
-        },
-        {
-          "type": "patreon",
-          "url": "https://patreon.com/mdevils"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/css-tree": {
       "version": "3.1.0",
@@ -3750,19 +3519,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/direction": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/direction/-/direction-2.0.1.tgz",
-      "integrity": "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA==",
-      "license": "MIT",
-      "bin": {
-        "direction": "cli.js"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
@@ -4101,18 +3857,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/expressive-code": {
-      "version": "0.41.3",
-      "resolved": "https://registry.npmjs.org/expressive-code/-/expressive-code-0.41.3.tgz",
-      "integrity": "sha512-YLnD62jfgBZYrXIPQcJ0a51Afv9h8VlWqEGK9uU2T5nL/5rb8SnA86+7+mgCZe5D34Tff5RNEA5hjNVJYHzrFg==",
-      "license": "MIT",
-      "dependencies": {
-        "@expressive-code/core": "^0.41.3",
-        "@expressive-code/plugin-frames": "^0.41.3",
-        "@expressive-code/plugin-shiki": "^0.41.3",
-        "@expressive-code/plugin-text-markers": "^0.41.3"
-      }
-    },
     "node_modules/exsolve": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
@@ -4273,39 +4017,6 @@
       "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
       "license": "MIT"
     },
-    "node_modules/hast-util-embedded": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-embedded/-/hast-util-embedded-3.0.0.tgz",
-      "integrity": "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-is-element": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-format": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/hast-util-format/-/hast-util-format-1.1.0.tgz",
-      "integrity": "sha512-yY1UDz6bC9rDvCWHpx12aIBGRG7krurX0p0Fm6pT547LwDIZZiNr8a+IHDogorAdreULSEzP82Nlv5SZkHZcjA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-embedded": "^3.0.0",
-        "hast-util-minify-whitespace": "^1.0.0",
-        "hast-util-phrasing": "^3.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "html-whitespace-sensitive-tag-names": "^3.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-from-dom": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
@@ -4375,32 +4086,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-has-property": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
-      "integrity": "sha512-MNilsvEKLFpV604hwfhVStK0usFY/QmM5zX16bo7EjnAEGofr5YyI37kzopBlZJkHD4t887i+q/C8/tr5Q94cA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-is-body-ok-link": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-is-body-ok-link/-/hast-util-is-body-ok-link-3.0.1.tgz",
-      "integrity": "sha512-0qpnzOBLztXHbHQenVB8uNuxTnm/QBFUOmdOSsEn7GnBtyY07+ENTWVFBAnXd/zEgd9/SUG3lRY7hSIBWRgGpQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
@@ -4414,23 +4099,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-minify-whitespace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-minify-whitespace/-/hast-util-minify-whitespace-1.0.1.tgz",
-      "integrity": "sha512-L96fPOVpnclQE0xzdWb/D12VT5FabA7SnZOUMtL1DbXmYiHJMXZvFkIZfiMmTCNJHUeO2K9UYNXoVyfz+QHuOw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-embedded": "^3.0.0",
-        "hast-util-is-element": "^3.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-parse-selector": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
@@ -4438,23 +4106,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-phrasing": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-phrasing/-/hast-util-phrasing-3.0.1.tgz",
-      "integrity": "sha512-6h60VfI3uBQUxHqTyMymMZnEbNl1XmEGtOxxKYL7stY2o601COo62AWAYBQR9lZbYXYSBoxag8UpPRXK+9fqSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-embedded": "^3.0.0",
-        "hast-util-has-property": "^3.0.0",
-        "hast-util-is-body-ok-link": "^3.0.0",
-        "hast-util-is-element": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4479,33 +4130,6 @@
         "unist-util-visit": "^5.0.0",
         "vfile": "^6.0.0",
         "web-namespaces": "^2.0.0",
-        "zwitch": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-select": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/hast-util-select/-/hast-util-select-6.0.4.tgz",
-      "integrity": "sha512-RqGS1ZgI0MwxLaKLDxjprynNzINEkRHY2i8ln4DDjgv9ZhcYVIHN9rlpiYsqtFwrgpYU361SyWDQcGNIBVu3lw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "bcp-47-match": "^2.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "css-selector-parser": "^3.0.0",
-        "devlop": "^1.0.0",
-        "direction": "^2.0.0",
-        "hast-util-has-property": "^3.0.0",
-        "hast-util-to-string": "^3.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "nth-check": "^2.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "unist-util-visit": "^5.0.0",
         "zwitch": "^2.0.0"
       },
       "funding": {
@@ -4620,19 +4244,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/hast-util-to-string": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
-      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-to-text": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
@@ -4695,44 +4306,11 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/html-whitespace-sensitive-tag-names": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/html-whitespace-sensitive-tag-names/-/html-whitespace-sensitive-tag-names-3.0.1.tgz",
-      "integrity": "sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause"
-    },
-    "node_modules/i18next": {
-      "version": "23.16.8",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
-      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://locize.com"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.2"
-      }
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -4942,15 +4520,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/klona": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
-      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/kolorist": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
@@ -5081,27 +4650,6 @@
         "@types/mdast": "^4.0.0",
         "@types/unist": "^3.0.0",
         "unist-util-visit": "^5.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-directive": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-3.1.0.tgz",
-      "integrity": "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "@types/unist": "^3.0.0",
-        "ccount": "^2.0.0",
-        "devlop": "^1.0.0",
-        "mdast-util-from-markdown": "^2.0.0",
-        "mdast-util-to-markdown": "^2.0.0",
-        "parse-entities": "^4.0.0",
-        "stringify-entities": "^4.0.0",
-        "unist-util-visit-parents": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5536,25 +5084,6 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-extension-directive": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-3.0.2.tgz",
-      "integrity": "sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==",
-      "license": "MIT",
-      "dependencies": {
-        "devlop": "^1.0.0",
-        "micromark-factory-space": "^2.0.0",
-        "micromark-factory-whitespace": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0",
-        "parse-entities": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-gfm": {
@@ -6440,6 +5969,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0"
@@ -6530,22 +6060,6 @@
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.3.0.tgz",
       "integrity": "sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ==",
       "license": "MIT"
-    },
-    "node_modules/pagefind": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.3.0.tgz",
-      "integrity": "sha512-8KPLGT5g9s+olKMRTU9LFekLizkVIu9tes90O1/aigJ0T5LmyPqTzGJrETnSw3meSYg58YH7JTzhTTW/3z6VAw==",
-      "license": "MIT",
-      "bin": {
-        "pagefind": "lib/runner/bin.cjs"
-      },
-      "optionalDependencies": {
-        "@pagefind/darwin-arm64": "1.3.0",
-        "@pagefind/darwin-x64": "1.3.0",
-        "@pagefind/linux-arm64": "1.3.0",
-        "@pagefind/linux-x64": "1.3.0",
-        "@pagefind/windows-x64": "1.3.0"
-      }
     },
     "node_modules/pako": {
       "version": "0.2.9",
@@ -6744,44 +6258,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/postcss-nested": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
-      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "postcss-selector-parser": "^6.1.1"
-      },
-      "engines": {
-        "node": ">=12.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.14"
-      }
-    },
-    "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/prismjs": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -6962,29 +6438,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/rehype-expressive-code": {
-      "version": "0.41.3",
-      "resolved": "https://registry.npmjs.org/rehype-expressive-code/-/rehype-expressive-code-0.41.3.tgz",
-      "integrity": "sha512-8d9Py4c/V6I/Od2VIXFAdpiO2kc0SV2qTJsRAaqSIcM9aruW4ASLNe2kOEo1inXAAkIhpFzAHTc358HKbvpNUg==",
-      "license": "MIT",
-      "dependencies": {
-        "expressive-code": "^0.41.3"
-      }
-    },
-    "node_modules/rehype-format": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/rehype-format/-/rehype-format-5.0.1.tgz",
-      "integrity": "sha512-zvmVru9uB0josBVpr946OR8ui7nJEdzZobwLOOqHb/OOD88W0Vk2SqLwoVOj0fM6IPCCO6TaV9CvQvJMWwukFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "hast-util-format": "^1.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/rehype-katex": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
@@ -7085,22 +6538,6 @@
       "dependencies": {
         "@types/hast": "^3.0.0",
         "hast-util-to-html": "^9.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-directive": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-3.0.1.tgz",
-      "integrity": "sha512-gwglrEQEZcZYgVyG1tQuA+h58EZfq5CSULw7J90AFuCTyib1thgHPoqQ+h9iFvU6R+vnZ5oNFQR5QKgGpk741A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-directive": "^3.0.0",
-        "micromark-extension-directive": "^3.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -8098,12 +7535,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "11.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@astrojs/mdx": "^4.3.4",
     "@astrojs/rss": "^4.0.12",
     "@astrojs/sitemap": "^3.5.0",
-    "@astrojs/starlight": "^0.35.2",
     "@playwright/test": "^1.54.2",
     "astro": "^5.13.2",
     "rehype-katex": "^7.0.1",

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,22 +1,16 @@
 import { glob } from 'astro/loaders';
 import { defineCollection, z } from 'astro:content';
-import { docsLoader } from '@astrojs/starlight/loaders';
-import { docsSchema } from '@astrojs/starlight/schema';
 
 const blog = defineCollection({
-	loader: glob({ base: './src/content/docs/blog', pattern: '**/*.{md,mdx}' }),
-	// Type-check frontmatter using a schema
-	schema: z.object({
-		title: z.string(),
-		description: z.string(),
-		// Transform string to Date object
-		pubDate: z.coerce.date(),
-		updatedDate: z.coerce.date().optional(),
-		heroImage: z.string().optional(),
-		tags: z.array(z.string()).optional(),
-	}),
+  loader: glob({ base: './src/content/docs/blog', pattern: '**/*.{md,mdx}' }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    pubDate: z.coerce.date(),
+    updatedDate: z.coerce.date().optional(),
+    heroImage: z.string().optional(),
+    tags: z.array(z.string()).optional(),
+  }),
 });
 
-const docs = defineCollection({ loader:docsLoader(), schema: docsSchema() });
-
-export const collections = { blog, docs };
+export const collections = { blog };

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,0 +1,75 @@
+---
+interface Props {
+  title?: string;
+  description?: string;
+}
+
+const {
+  title = 'WTN Mother Base | Weekend Thinker Nexus',
+  description = '思考の断片からストランドへ。WTNの知的生産活動を接続するハブ。',
+} = Astro.props;
+---
+
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="generator" content={Astro.generator} />
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={new URL(Astro.url.pathname, Astro.site).toString()} />
+    <meta name="twitter:card" content="summary_large_image" />
+    <link rel="canonical" href={new URL(Astro.url.pathname, Astro.site).toString()} />
+    <link rel="icon" href="/favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Noto+Sans+JP:wght@400;500;700&display=swap" />
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>
+
+<style is:global>
+  :root {
+    --bg: #06070a;
+    --surface: #0f131b;
+    --text: #e8ecf6;
+    --muted: #9ca8c3;
+    --line: rgba(153, 176, 255, 0.24);
+    --accent: #85a4ff;
+    --accent-2: #70d9c6;
+    --max: 1080px;
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+
+  html,
+  body {
+    margin: 0;
+    padding: 0;
+    background: radial-gradient(circle at 20% -10%, #1f2b56 0%, transparent 40%),
+      radial-gradient(circle at 75% 0%, #1e4b46 0%, transparent 40%),
+      var(--bg);
+    color: var(--text);
+    font-family: 'Inter', 'Noto Sans JP', system-ui, -apple-system, sans-serif;
+    line-height: 1.7;
+  }
+
+  a {
+    color: inherit;
+    text-decoration-color: color-mix(in srgb, var(--accent) 70%, white);
+    text-underline-offset: 0.2em;
+  }
+
+  .container {
+    width: min(100% - 2rem, var(--max));
+    margin-inline: auto;
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,219 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+const channels = [
+  {
+    title: 'Essays / Note',
+    description: '日次で生まれる短編のアーカイブ。思考断片を連続的に公開。',
+    href: 'https://note.com/',
+    state: 'external',
+  },
+  {
+    title: 'Video / YouTube',
+    description: 'ストランド化した思考を映像で再構成。',
+    href: 'https://www.youtube.com/',
+    state: 'external',
+  },
+  {
+    title: 'Music',
+    description: '言語化できない層を音として抽出する実験ライン。',
+    href: '#',
+    state: 'coming-soon',
+  },
+  {
+    title: 'GitHub',
+    description: '知の構造化を支える実装・運用記録。',
+    href: 'https://github.com/LogPiyo',
+    state: 'external',
+  },
+  {
+    title: 'X / Notes',
+    description: '瞬間的な洞察・観測ログを高頻度で記録。',
+    href: 'https://x.com/LogPiyoo',
+    state: 'external',
+  },
+];
+
+const layers = [
+  {
+    name: 'Direct Layer',
+    ja: '直接層',
+    detail: '意識そのもの（クオリア、自己、主観性）。',
+  },
+  {
+    name: 'Indirect Layer',
+    ja: '間接層',
+    detail: '認識、言語、知識、モデル化。',
+  },
+  {
+    name: 'Extension Layer',
+    ja: '外延層',
+    detail: '物理、社会、文化、技術。',
+  },
+];
+---
+
+<BaseLayout>
+  <header class="hero container">
+    <p class="eyebrow">WEEKEND THINKER NEXUS / MOTHER BASE</p>
+    <h1>思考の進化過程を接続する HUB</h1>
+    <p>
+      このサイトは、断片 → 糸 → ストランドへと変化する知的生産活動を統合する中核ハブです。
+      コンテンツ生成は外部メディアで行い、ここでは索引・関係性・進化履歴を扱います。
+    </p>
+  </header>
+
+  <main class="container">
+    <section class="panel">
+      <h2>MB Mission</h2>
+      <ul>
+        <li>WTNに属する複数メディアの横断接続</li>
+        <li>思考構造の可視化と追跡可能性の担保</li>
+        <li>発信成果ではなく進化プロセスそのものの外部化</li>
+      </ul>
+    </section>
+
+    <section class="panel">
+      <h2>Hub Links</h2>
+      <div class="grid">
+        {channels.map((link) => (
+          <a class="card" href={link.href} target={link.state === 'external' ? '_blank' : undefined} rel="noreferrer">
+            <div>
+              <h3>{link.title}</h3>
+              <p>{link.description}</p>
+            </div>
+            <span class:list={{ tag: true, soon: link.state === 'coming-soon' }}>
+              {link.state === 'coming-soon' ? 'Coming Soon' : 'Open'}
+            </span>
+          </a>
+        ))}
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>Consciousness-oriented Architecture</h2>
+      <p class="small">すべての学問は最終的に「意識とは何か」という問いへ収束する。</p>
+      <div class="layers">
+        {layers.map((layer) => (
+          <article>
+            <h3>{layer.name} <span>{layer.ja}</span></h3>
+            <p>{layer.detail}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  </main>
+
+  <footer class="container footer">
+    <p>© {new Date().getFullYear()} WTN Mother Base</p>
+  </footer>
+</BaseLayout>
+
+<style>
+  .hero {
+    padding: 5rem 0 2.5rem;
+  }
+
+  .eyebrow {
+    color: var(--accent-2);
+    font-size: 0.85rem;
+    letter-spacing: 0.1em;
+    margin: 0;
+  }
+
+  h1 {
+    font-size: clamp(2rem, 4vw, 3.2rem);
+    line-height: 1.2;
+    margin: 0.75rem 0 1rem;
+    max-width: 20ch;
+  }
+
+  .panel {
+    border: 1px solid var(--line);
+    border-radius: 20px;
+    background: color-mix(in srgb, var(--surface) 90%, black);
+    backdrop-filter: blur(6px);
+    padding: 1.5rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .grid {
+    display: grid;
+    gap: 0.9rem;
+    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  }
+
+  .card {
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    padding: 1rem;
+    background: rgba(11, 15, 23, 0.75);
+    text-decoration: none;
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    transition: transform 0.2s ease, border-color 0.2s ease;
+  }
+
+  .card:hover {
+    transform: translateY(-2px);
+    border-color: color-mix(in srgb, var(--accent) 70%, white);
+  }
+
+  .card h3 {
+    margin: 0 0 0.4rem;
+    font-size: 1rem;
+  }
+
+  .card p {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.95rem;
+  }
+
+  .tag {
+    font-size: 0.78rem;
+    align-self: flex-start;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    padding: 0.2rem 0.6rem;
+    color: var(--accent-2);
+    white-space: nowrap;
+  }
+
+  .soon {
+    color: #ffd38a;
+  }
+
+  .layers {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+
+  .layers article {
+    border-left: 2px solid var(--accent);
+    padding-left: 0.8rem;
+  }
+
+  .layers h3 {
+    margin: 0;
+    font-size: 1rem;
+  }
+
+  .layers span {
+    color: var(--muted);
+    font-size: 0.85rem;
+    margin-left: 0.3rem;
+  }
+
+  .small {
+    color: var(--muted);
+  }
+
+  .footer {
+    padding: 1.5rem 0 2rem;
+    color: var(--muted);
+    font-size: 0.85rem;
+  }
+</style>


### PR DESCRIPTION
### Motivation

- Replace the `@astrojs/starlight` dependent setup with a minimal, plain Astro configuration to prioritize build speed and SEO for an initial HUB release.
- Deliver a focused HUB (index) page that serves as a world-aware link hub (Mother Base) with clear mission and cross-media links.
- Simplify content configuration to remove Starlight-specific loaders while keeping the existing blog collection accessible.

### Description

- Removed the `@astrojs/starlight` integration and dependency and simplified `astro.config.mjs` to a minimal config with `sitemap` integration, `output: 'static'`, and `compressHTML` enabled. 
- Added a new global layout `src/layouts/BaseLayout.astro` providing SEO meta tags (canonical/OG/Twitter), fonts, and a dark-themed global visual style. 
- Implemented the HUB landing as `src/pages/index.astro` with MB mission, outward media links, and the three-layer conceptual section (`Direct/Indirect/Extension`).
- Updated `src/content.config.ts` to remove Starlight loaders/schemas and retain a plain `blog` collection, and removed Starlight from `package.json`/`package-lock.json`.

### Testing

- Ran `npm run build` which completed successfully and produced static output in `dist/` without build errors. 
- Build output shows static routes for `/index.html` and `/rss.xml` were generated. 
- The build emitted pre-existing content warnings (MDX/glob entry-type warnings and an unsupported `hdl` Shiki language); these are warnings only and did not block the HUB build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c24eab39e88325a78f906a4c577739)